### PR TITLE
Fixed video not loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
                </div>
                <div class="post">
                 <video height="400px" width="200px"  controls autoplay>
-                    <source src="/postVideo/post1.mp4.mp4" type="video/mp4">
+                    <source src="postVideo/post1.mp4.mp4" type="video/mp4">
                 </video>
 
                </div>


### PR DESCRIPTION
The Video was not loading because Github put the home page of the site at `[username].github.io/TwitterClone` and not `[username].github.io/`

`/[link to the video]` becomes `[username].github.io/[link to the video]` when it needed to be

`[username].github.io/TwitterClone/[link to the video]`

So I renamed the link from `/[link to the video]` to `[link to the video]` changed the absolute path to relative path.